### PR TITLE
few minor changes

### DIFF
--- a/fix_hmc.cpp
+++ b/fix_hmc.cpp
@@ -437,9 +437,8 @@ void FixHMC::init()
 
 void FixHMC::setup(int vflag)
 {
-  if (rigid_flag)
-    if (fix_rigid->extended)
-      error->all(FLERR,"fix hmc does not support extended particles");
+  if ((rigid_flag) && (fix_rigid->extended))
+    error->all(FLERR,"fix hmc does not support extended particles");
 
   // Compute properties of the initial state:
   nattempts = 0;

--- a/fix_hmc.cpp
+++ b/fix_hmc.cpp
@@ -70,14 +70,12 @@ FixHMC::FixHMC(LAMMPS *lmp, int narg, char **arg) :
   mbeta = -1.0/(force->boltz * temp);           // -1/(K*T) in energy units
 
   // Check keywords:
+  tune_flag = 0; // default
   int iarg = 7;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"adjust") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix hmc command");
-      if (strcmp(arg[iarg+1],"yes") == 0) tune_flag = 1;
-      else if (strcmp(arg[iarg+1],"no") == 0) tune_flag = 0;
-      else error->all(FLERR,"Illegal fix hmc command");
-      iarg += 2;
+      tune_flag = 1;
+      iarg += 1;
     }
     else error->all(FLERR,"Illegal fix hmc command");
   }

--- a/fix_hmc.txt
+++ b/fix_hmc.txt
@@ -1,0 +1,46 @@
+"LAMMPS WWW Site"_lws - "LAMMPS Documentation"_ld - "LAMMPS Commands"_lc :c
+
+:link(lws,http://lammps.sandia.gov)
+:link(ld,Manual.html)
+:link(lc,Section_commands.html#comm)
+
+:line
+
+fix hmc command :h3
+
+[Syntax:]
+
+fix ID group-ID hmc N integrator seed T keyword values ... :pre
+
+ID, group-ID are documented in "fix"_fix.html command :ulb,l
+hmc = style name of this fix command :l
+N = run MD N steps between MC acceptance protocol :l
+integrator = flexible or rigid :l
+seed = random # seed (positive integer) :l
+T = temperature of the simulation box (temperature units) :l
+zero or more keyword/value pairs may be appended to args :l
+keyword = {adjust}
+  {adjust} = adjust the value of stuff (Ana, we need to fill in detail here.)
+:ule
+
+[Examples:]
+
+fix 2 all hmc 5 273 783246 flexible adjust
+fix 3 all hmc 5 273 783246 rigid
+
+[Description:]
+
+This fix performs a hybrid Monte Carlo (HMC) simulation. (Ana, 
+we need to fill in detail here.)
+
+[Restrictions:]
+
+This fix is part of the USER-MISC package.  It is only enabled if
+LAMMPS was built with that package.  See the "Making
+LAMMPS"_Section_start.html#start_3 section for more info.
+
+[Related commands:] none
+
+[Default:]
+
+The option defaults are adjust = no.

--- a/testing/butane_rigid.inp
+++ b/testing/butane_rigid.inp
@@ -29,7 +29,7 @@ compute_modify  thermo_temp extra 0
 timestep	20
 
 fix		1 all rigid/nve/small molecule
-fix		2 all hmc 10 5643 ${T} 1 adjust yes
+fix		2 all hmc 10 5643 ${T} rigid adjust yes
 
 
 compute		eatom all pe/atom

--- a/testing/butane_rigid.inp
+++ b/testing/butane_rigid.inp
@@ -29,7 +29,7 @@ compute_modify  thermo_temp extra 0
 timestep	20
 
 fix		1 all rigid/nve/small molecule
-fix		2 all hmc 10 5643 ${T} rigid adjust yes
+fix		2 all hmc 10 5643 ${T} rigid adjust
 
 
 compute		eatom all pe/atom

--- a/testing/propane_rigid.inp
+++ b/testing/propane_rigid.inp
@@ -19,7 +19,7 @@ neighbor	${skin} bin
 neigh_modify	delay 0 every 1
 
 fix		1 all rigid/small molecule
-fix		2 all hmc 3 8768 200 rigid adjust yes
+fix		2 all hmc 3 8768 200 rigid adjust
 
 thermo		40
 thermo_style	custom step press temp pe ke f_2[1] f_2[2] f_2[3]

--- a/testing/propane_rigid.inp
+++ b/testing/propane_rigid.inp
@@ -19,7 +19,7 @@ neighbor	${skin} bin
 neigh_modify	delay 0 every 1
 
 fix		1 all rigid/small molecule
-fix		2 all hmc 3 8768 200 1 adjust yes
+fix		2 all hmc 3 8768 200 rigid adjust yes
 
 thermo		40
 thermo_style	custom step press temp pe ke f_2[1] f_2[2] f_2[3]


### PR DESCRIPTION
3 main changes:
1. A minor combination of two "if" statements
2. An addition of a skeleton documentation file that we can build upon.
3. A change of the "adjust" keyword so that just its absence/presence is needed, and not a "yes/no" after it. This is more similar to the existing LAMMPS style, such as the "full_energy" flag in fix_gcmc.

I also made some changes to the "testing" files. One change is just to reflect my change made to the "adjust" keyword, but the other reverts the "integrator" variable back to "rigid" instead of 1. Why was this variable changed to 1 in the last commit?